### PR TITLE
Prettier line ending rule for windows environment

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "arrowParens": "avoid",
-  "semi": false
+  "semi": false,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
Prettier was throwing errors trying to build on windows due to line endings, and this rule stops the errors.